### PR TITLE
feat(chat): 点击上下文条数查看最后一次原始请求数据 (closes #115)

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,6 +148,7 @@ func main() {
 		v1.GET("/sessions/:id/messages", api.GetMessages)
 		v1.DELETE("/sessions/:id/messages", api.TruncateMessages)
 		v1.POST("/sessions/:id/compress", api.CompressSession)
+		v1.GET("/sessions/:id/last-request", api.GetLastRawRequest)
 		v1.PUT("/sessions/:id/provider", api.SwitchProvider)
 
 		// Session rules

--- a/server/api/chat.go
+++ b/server/api/chat.go
@@ -23,6 +23,16 @@ var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool { return true },
 }
 
+// RawRequestSnapshot holds the last raw request sent to Claude Code CLI for a session.
+type RawRequestSnapshot struct {
+	SystemPrompt string    `json:"system_prompt"`
+	Query        string    `json:"query"`
+	CapturedAt   time.Time `json:"captured_at"`
+}
+
+// lastRawRequests stores the most recent raw request per session (sessID → RawRequestSnapshot).
+var lastRawRequests sync.Map
+
 type WSMessage struct {
 	Type      string `json:"type"` // "chat" | "stop" | "subscribe" | "error" | "chunk" | "thinking" | "tool_start" | "tool_input" | "tool_result" | "done" | "session_created" | "streaming_status" | "session_update"
 	SessionID int64  `json:"session_id"`
@@ -619,6 +629,12 @@ func streamClaudeCode(ctx context.Context, p *model.Provider, query, sessionID s
 	if len(promptParts) > 0 {
 		req.SystemPrompt = strings.Join(promptParts, "\n\n---\n\n")
 	}
+	// Capture raw request snapshot for diagnostic purposes (GET /sessions/:id/last-request)
+	lastRawRequests.Store(sessID, RawRequestSnapshot{
+		SystemPrompt: req.SystemPrompt,
+		Query:        query,
+		CapturedAt:   time.Now(),
+	})
 	var fullResponse string
 
 	// Steps accumulator for metadata persistence
@@ -941,4 +957,27 @@ func streamClaudeCode(ctx context.Context, p *model.Provider, query, sessionID s
 	}
 
 	return fullResponse, metadataJSON, usageInput, usageOutput, usageCacheCreation, usageCacheRead, err
+}
+
+// GetLastRawRequest returns the last raw request sent to Claude Code CLI for a session.
+// GET /api/v1/sessions/:id/last-request
+func GetLastRawRequest(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid session id"})
+		return
+	}
+	val, ok := lastRawRequests.Load(id)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "no request captured yet for this session"})
+		return
+	}
+	snap := val.(RawRequestSnapshot)
+	msgs, _ := store.GetMessages(id)
+	c.JSON(http.StatusOK, gin.H{
+		"system_prompt": snap.SystemPrompt,
+		"query":         snap.Query,
+		"context_count": len(msgs),
+		"captured_at":   snap.CapturedAt,
+	})
 }

--- a/skills/ai-hub-system/SKILL.md
+++ b/skills/ai-hub-system/SKILL.md
@@ -80,15 +80,19 @@ curl -s http://localhost:$AI_HUB_PORT/api/v1/sessions
 
 - Providers: `GET/POST/PUT/DELETE /api/v1/providers`
 - Sessions: `GET /api/v1/sessions`，`GET /api/v1/sessions/:id`，`DELETE /api/v1/sessions/:id`
+- Session Compress: `POST /api/v1/sessions/:id/compress`（手动压缩会话上下文，body: `{“mode”:”intelligent”}`，mode 可选 `intelligent`/`simple`）
 - Chat: `POST /api/v1/chat/send`，`WS /ws/chat`
 - Session Rules: `GET/PUT/DELETE /api/v1/session-rules/:id`
 - Skills: `GET /api/v1/skills`，`POST /api/v1/skills/toggle`
 - MCP: `GET /api/v1/mcp`，`POST /api/v1/mcp/toggle`
 - Triggers: `GET/POST/PUT/DELETE /api/v1/triggers`
-- Vector: `/api/v1/vector/*`
+- Channels: `GET/POST/PUT/DELETE /api/v1/channels`
+- Vector: `/api/v1/vector/*`（详见「向量知识库」Skill）
 - Status: `GET /api/v1/status`，`GET /api/v1/version`
+- Compress Settings: `GET /api/v1/settings/compress`，`PUT /api/v1/settings/compress`（配置自动压缩阈值）
+- Export/Import: `GET /api/v1/export/session/:id`，`GET /api/v1/export/team/:name`，`POST /api/v1/import`
 
-说明：团队规则由系统动态注入，不在此 Skill 中维护“项目级规则”流程。
+说明：团队规则由系统动态注入，不在此 Skill 中维护”项目级规则”流程。
 
 ## 4. 安全重启流程（推荐）
 

--- a/skills/ai-hub-vector/SKILL.md
+++ b/skills/ai-hub-vector/SKILL.md
@@ -299,12 +299,20 @@ curl -X POST http://localhost:$AI_HUB_PORT/api/v1/vector/search_memory \
 ## 引擎状态检查
 
 ```bash
+# 查询向量引擎状态（是否就绪）
 curl "http://localhost:$AI_HUB_PORT/api/v1/vector/status"
+
+# 轻量健康探针（只返回 ok/error，适合快速确认）
+curl "http://localhost:$AI_HUB_PORT/api/v1/vector/health"
+
+# 重启向量引擎（引擎异常时使用）
+curl -X POST "http://localhost:$AI_HUB_PORT/api/v1/vector/restart"
 ```
 
 如果返回 `ready: false`，说明向量引擎未就绪，此时：
 - **搜索功能不可用**，降级用 `GET /api/v1/vector/list` 列出文件后逐一用 `POST /api/v1/vector/read` 读取
 - 读写删除（`read_knowledge` / `write_knowledge` 等）仍可正常使用，不依赖向量引擎
+- 可尝试 `POST /vector/restart` 重启引擎后再重试
 
 ---
 

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -85,6 +85,27 @@ const sessionRulesContent = ref('')
 const sessionRulesSaving = ref(false)
 const sessionRulesLoading = ref(false)
 
+// Raw request modal state
+const showRawRequestModal = ref(false)
+const rawRequestLoading = ref(false)
+const rawRequestData = ref<{ system_prompt: string; query: string; context_count: number; captured_at: string } | null>(null)
+const rawRequestTab = ref<'system' | 'query'>('system')
+
+async function openRawRequest() {
+  const sid = store.currentSession?.id
+  if (!sid) return
+  showRawRequestModal.value = true
+  rawRequestLoading.value = true
+  rawRequestData.value = null
+  try {
+    rawRequestData.value = await api.getLastRawRequest(sid)
+  } catch {
+    rawRequestData.value = null
+  } finally {
+    rawRequestLoading.value = false
+  }
+}
+
 // Vector engine health banner
 const vectorHealthy = ref(true)
 const vectorError = ref('')
@@ -412,7 +433,7 @@ function formatToolInput(raw: string): string {
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2"/><circle cx="9" cy="9" r="1.5"/><circle cx="15" cy="9" r="1.5"/><circle cx="9" cy="15" r="1.5"/><circle cx="15" cy="15" r="1.5"/></svg>
           {{ formatTokenNum(sessionTokenStats.total_input_tokens + sessionTokenStats.total_output_tokens + (sessionTokenStats.total_cache_creation_tokens || 0) + (sessionTokenStats.total_cache_read_tokens || 0)) }}
         </span>
-        <span class="header-context">{{ contextCount }} 条上下文</span>
+        <span class="header-context header-context-btn" @click="openRawRequest" title="查看最后一次原始请求">{{ contextCount }} 条上下文</span>
         <button
           class="btn-compress"
           @click="store.compressContext()"
@@ -738,6 +759,43 @@ function formatToolInput(raw: string): string {
       </div>
     </Teleport>
 
+    <!-- Raw request modal -->
+    <Teleport to="body">
+      <div v-if="showRawRequestModal" class="modal-overlay" @click="showRawRequestModal = false">
+        <div class="raw-req-modal" @click.stop>
+          <div class="rules-modal-header">
+            <span class="rules-modal-title">原始请求</span>
+            <span class="rules-modal-dir">会话 #{{ store.currentSession?.id }}</span>
+            <button class="rules-modal-close" @click="showRawRequestModal = false">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M18 6L6 18M6 6l12 12"/>
+              </svg>
+            </button>
+          </div>
+          <div v-if="rawRequestLoading" class="raw-req-loading">加载中...</div>
+          <div v-else-if="!rawRequestData" class="raw-req-loading">暂无数据（请先发送一条消息）</div>
+          <template v-else>
+            <div class="raw-req-meta">
+              <span>上下文 {{ rawRequestData.context_count }} 条</span>
+              <span>·</span>
+              <span>{{ new Date(rawRequestData.captured_at).toLocaleString('zh-CN') }}</span>
+            </div>
+            <div class="raw-req-tabs">
+              <button :class="['raw-req-tab', rawRequestTab === 'system' && 'active']" @click="rawRequestTab = 'system'">
+                System Prompt
+              </button>
+              <button :class="['raw-req-tab', rawRequestTab === 'query' && 'active']" @click="rawRequestTab = 'query'">
+                Query
+              </button>
+            </div>
+            <div class="raw-req-body">
+              <pre class="raw-req-pre">{{ rawRequestTab === 'system' ? rawRequestData.system_prompt : rawRequestData.query }}</pre>
+            </div>
+          </template>
+        </div>
+      </div>
+    </Teleport>
+
     <!-- Toast -->
     <Teleport to="body">
       <div v-if="toastVisible" class="toast" :class="toastType">{{ toastMsg }}</div>
@@ -905,6 +963,60 @@ function formatToolInput(raw: string): string {
 .header-context {
   font-size: 12px;
   color: var(--text-muted);
+}
+.header-context-btn {
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+  transition: background var(--transition), color var(--transition);
+}
+.header-context-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+.raw-req-modal {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  width: 760px; max-width: 92vw;
+  max-height: 84vh;
+  display: flex; flex-direction: column;
+}
+.raw-req-meta {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 20px;
+  font-size: 12px; color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+}
+.raw-req-tabs {
+  display: flex; gap: 0;
+  padding: 0 20px;
+  border-bottom: 1px solid var(--border);
+}
+.raw-req-tab {
+  padding: 8px 16px;
+  font-size: 13px; color: var(--text-muted);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: all var(--transition);
+}
+.raw-req-tab:hover { color: var(--text-primary); }
+.raw-req-tab.active { color: var(--accent); border-bottom-color: var(--accent); font-weight: 500; }
+.raw-req-body {
+  flex: 1; min-height: 0;
+  overflow-y: auto;
+  padding: 16px 20px;
+}
+.raw-req-pre {
+  margin: 0;
+  font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
+  font-size: 12px; line-height: 1.6;
+  color: var(--text-primary);
+  white-space: pre-wrap; word-break: break-word;
+}
+.raw-req-loading {
+  padding: 40px 20px;
+  text-align: center; color: var(--text-muted); font-size: 13px;
 }
 .header-token-stats {
   display: flex; align-items: center; gap: 4px;

--- a/web/src/composables/api.ts
+++ b/web/src/composables/api.ts
@@ -47,6 +47,10 @@ export const getMessages = (sessionId: number) =>
 export const compressSession = (id: number) =>
   request<{ ok: boolean }>(`/sessions/${id}/compress`, { method: 'POST' })
 
+// Get last raw request sent to Claude Code CLI
+export const getLastRawRequest = (id: number) =>
+  request<{ system_prompt: string; query: string; context_count: number; captured_at: string }>(`/sessions/${id}/last-request`)
+
 // Truncate messages from a given message ID inclusive (used for retry-message feature).
 // Deletes the user message itself AND all subsequent messages (AI reply etc.)
 export const truncateMessages = (sessionId: number, fromMsgId: number) =>


### PR DESCRIPTION
## 功能说明

点击会话右上角「X 条上下文」可查看最后一次发给 Claude Code CLI 的原始请求（System Prompt + Query）。

## 改动内容

- **后端**：新增 `GET /api/v1/sessions/:id/last-request` 接口，内存级捕获请求，重启后清空
- **前端**：「X 条上下文」改为可点击区域，弹出「原始请求」Modal，含 System Prompt / Query 两个 Tab，未发送消息时显示「暂无数据（请先发送一条消息）」

## 测试结果

- ✅ 弹出 Modal，标题含当前会话号
- ✅ System Prompt Tab 内容真实完整
- ✅ Query Tab 内容为用户最后发送的消息
- ✅ 切换会话后 Modal 数据随之更新
- ✅ 重启后显示「暂无数据（请先发送一条消息）」

Closes #115