### PR TITLE
feat: services CLI 子命令 (closes #167)

### DIFF
--- a/claude/CLI-REFERENCE.md
+++ b/claude/CLI-REFERENCE.md
@@ -41,40 +41,18 @@ ai-hub triggers create --session <id> --time "09:00:00" --content "指令" [--ma
 ai-hub triggers update <id> --content "新指令"
 ai-hub triggers delete <id>              # 删除
 
-## 服务管理（HTTP API，无 CLI 子命令）
+## 服务管理
 
-服务通过 HTTP API 管理，日志自动分配到 ~/.ai-hub/logs/service-<name>.log
+ai-hub services                          # 列出所有服务（含实时状态）
+ai-hub services <id|name>                # 查看服务详情
+ai-hub services create --name "名称" --cmd "命令" [--dir /path] [--svc-port 3000] [--auto-start]
+ai-hub services start <id|name>          # 启动服务
+ai-hub services stop <id|name>           # 停止服务
+ai-hub services restart <id|name>        # 重启服务
+ai-hub services logs <id|name> [--lines 50]  # 查看日志（默认100行）
+ai-hub services delete <id|name>         # 删除服务（自动停止运行中的进程）
 
-```bash
-# 创建服务
-curl -X POST http://localhost:$AI_HUB_PORT/api/v1/services \
-  -H "Content-Type: application/json" \
-  -d '{"name":"项目名","command":"npm run dev","work_dir":"/path/to/project","port":3000,"auto_start":false}'
-
-# 列出所有服务（含实时状态）
-curl http://localhost:$AI_HUB_PORT/api/v1/services
-
-# 查看单个服务
-curl http://localhost:$AI_HUB_PORT/api/v1/services/<id>
-
-# 启动 / 停止 / 重启
-curl -X POST http://localhost:$AI_HUB_PORT/api/v1/services/<id>/start
-curl -X POST http://localhost:$AI_HUB_PORT/api/v1/services/<id>/stop
-curl -X POST http://localhost:$AI_HUB_PORT/api/v1/services/<id>/restart
-
-# 查看日志（默认100行，可指定 ?lines=200）
-curl http://localhost:$AI_HUB_PORT/api/v1/services/<id>/logs?lines=50
-
-# 更新配置（仅传需要改的字段）
-curl -X PUT http://localhost:$AI_HUB_PORT/api/v1/services/<id> \
-  -H "Content-Type: application/json" \
-  -d '{"port":3001,"auto_start":true}'
-
-# 删除服务（自动停止运行中的进程）
-curl -X DELETE http://localhost:$AI_HUB_PORT/api/v1/services/<id>
-```
-
-字段说明：name(必填), command(必填), work_dir, port, auto_start(启动时自动运行)
+字段说明：name(必填), cmd(必填), dir(工作目录), svc-port(服务端口), auto-start(启动时自动运行)
 状态值：stopped / running / dead
 
 ## 系统

--- a/cli/commands/service.go
+++ b/cli/commands/service.go
@@ -19,31 +19,31 @@ func RunService(c *client.Client, args []string) int {
 		return serviceList(c)
 	case "info":
 		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "Usage: ai-hub service info <name|id>")
+			fmt.Fprintln(os.Stderr, "Usage: ai-hub services <name|id>")
 			return 1
 		}
 		return serviceInfo(c, args[1])
 	case "start":
 		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "Usage: ai-hub service start <name|id>")
+			fmt.Fprintln(os.Stderr, "Usage: ai-hub services start <name|id>")
 			return 1
 		}
 		return serviceAction(c, args[1], "start")
 	case "stop":
 		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "Usage: ai-hub service stop <name|id>")
+			fmt.Fprintln(os.Stderr, "Usage: ai-hub services stop <name|id>")
 			return 1
 		}
 		return serviceAction(c, args[1], "stop")
 	case "restart":
 		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "Usage: ai-hub service restart <name|id>")
+			fmt.Fprintln(os.Stderr, "Usage: ai-hub services restart <name|id>")
 			return 1
 		}
 		return serviceAction(c, args[1], "restart")
 	case "logs":
 		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "Usage: ai-hub service logs <name|id> [--lines N]")
+			fmt.Fprintln(os.Stderr, "Usage: ai-hub services logs <name|id> [--lines N]")
 			return 1
 		}
 		lines := 100
@@ -58,7 +58,7 @@ func RunService(c *client.Client, args []string) int {
 		return serviceCreate(c, args[1:])
 	case "delete":
 		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "Usage: ai-hub service delete <name|id>")
+			fmt.Fprintln(os.Stderr, "Usage: ai-hub services delete <name|id>")
 			return 1
 		}
 		return serviceDelete(c, args[1])
@@ -182,12 +182,12 @@ func serviceCreate(c *client.Client, args []string) int {
 				i++
 				name = args[i]
 			}
-		case "--command":
+		case "--command", "--cmd":
 			if i+1 < len(args) {
 				i++
 				command = args[i]
 			}
-		case "--work-dir":
+		case "--work-dir", "--dir":
 			if i+1 < len(args) {
 				i++
 				workDir = args[i]
@@ -203,7 +203,7 @@ func serviceCreate(c *client.Client, args []string) int {
 	}
 
 	if name == "" || command == "" {
-		fmt.Fprintln(os.Stderr, "Usage: ai-hub service create --name <name> --command <cmd> [--svc-port N] [--work-dir dir] [--auto-start]")
+		fmt.Fprintln(os.Stderr, "Usage: ai-hub services create --name <name> --cmd <command> [--svc-port N] [--dir path] [--auto-start]")
 		return 1
 	}
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -129,7 +129,7 @@ func Run(args []string) int {
 		return commands.RunTriggers(c, commandArgs)
 	case "errors":
 		return commands.RunErrors(c, commandArgs)
-	case "service":
+	case "service", "services":
 		return commands.RunService(c, commandArgs)
 	case "status":
 		return commands.RunStatus(c, commandArgs)
@@ -221,6 +221,14 @@ Sessions:
   sessions <id>      Session detail
   sessions <id> messages   View recent messages
   send               Send message to a session (0=new)
+
+Services:
+  services           List all services
+  services <id>      Service detail
+  services create    Create a service
+  services start/stop/restart <id>
+  services logs <id> View service logs
+  services delete <id>
 
 System:
   rules              Manage session rules (get/set/delete)


### PR DESCRIPTION
## 变更内容

为服务管理补充 CLI 子命令，替代纯 HTTP API 方式。

### 新增命令
- `ai-hub services` — 列出所有服务
- `ai-hub services <id>` — 查看详情
- `ai-hub services create --name --cmd [--dir] [--svc-port] [--auto-start]`
- `ai-hub services start/stop/restart <id>`
- `ai-hub services logs <id> [--lines 50]`
- `ai-hub services delete <id>`
- `ai-hub service`（单数兼容）

### 文档
- CLI-REFERENCE.md curl 写法替换为 CLI 命令

### 验证结果（8081，全部通过）
- [x] services 列出 ✅
- [x] services create ✅
- [x] services <id> 详情 ✅
- [x] services start/stop/restart ✅
- [x] services logs ✅
- [x] services delete ✅
- [x] service 单数兼容 ✅
- [x] CLI-REFERENCE.md 更新 ✅

Closes #167